### PR TITLE
chore(build): Added --pre-release flag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,12 +1,15 @@
 'use strict';
 
 module.exports = function(grunt) {
+
+  var isPreReleaseBuild = grunt.option('pre-release') !== undefined; 
+
   // load all grunt tasks
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
-    buildversion: '<%= pkg.version %>-' + grunt.template.today('yymmddHHMM'),
+    buildversion: (isPreReleaseBuild) ? '<%= pkg.version %>-' + grunt.template.today('yymmddHHMM') : '<%= pkg.version %>',
     clean : {
       dist : {
         files : [ {


### PR DESCRIPTION
Added `--pre-release` flag so that build version includes timestamp only in case of a pre-release. By default timestamp will be omitted in the version property of `dist/bower.json`.

e.g.:
`grunt --pre-release`

When publishing a package to bower the package version string must be equal to the tag name for that package. As usually no pre-releases are getting released for this package the pre-release flag is false by default.

`(warning) bower mismatch      Version declared in the json (0.5.8-1407241001) is different than the resolved one (0.5.8)`

Sorry, didn't notice before that bower throws such warning
