### PR TITLE
Fix the iScrollInstance duplication

### DIFF
--- a/src/scrollable.js
+++ b/src/scrollable.js
@@ -227,10 +227,10 @@ angular.module('angular-momentum-scroll').directive('scrollable',
 
         var _refresh = function(nVal) {
             if (angular.isDefined(nVal)) {
-              if (angular.isDefined(iScrollInstance)) {
-                iScrollInstance.destroy();
-              }
               $timeout(function(){
+                if (angular.isDefined(iScrollInstance)) {
+                  iScrollInstance.destroy();
+                }
                 _init();
                 if (angular.isDefined(iScrollInstance.pages) &&
                   iScrollInstance.pages.length > 0) {


### PR DESCRIPTION
The scrollbar (iScrollInstance) was doubled when invoked the refresh.

Moving iScrollInstance.destroy(); within the "timeout", the bug is fixed.
